### PR TITLE
Librairie libindicator-gtk3 version 12.10.1

### DIFF
--- a/gui/libindicator-gtk3/Pkgfile
+++ b/gui/libindicator-gtk3/Pkgfile
@@ -1,0 +1,33 @@
+# Description: A set of symbols and convience functions for Ayatana indicators. 
+# URL: https://launchpad.net/libindicator
+# Packager: jayce dot net at gmail dot com
+# Depends on: gtk3
+
+name=libindicator-gtk3
+version=12.10.1
+release=1
+
+source=(http://launchpad.net/libindicator/12.10/$version/+download/libindicator-$version.tar.gz)
+
+build() {
+
+  sed '/-Werror/s/$/ -Wno-deprecated-declarations/' -i libindicator-$version/libindicator/Makefile.{am,in}
+  sed 's/LIBINDICATOR_LIBS+="$LIBM"/LIBINDICATOR_LIBS+=" $LIBM"/g' -i libindicator-$version/configure
+  sed 's/LIBM="-lmw"/LIBM=" -lmw"/g' -i libindicator-$version/configure
+  sed 's/LIBM="-lm"/LIBM=" -lm"/g' -i libindicator-$version/configure
+  sed 's/LIBS="-lm  $LIBS"/LIBS=" -lm  $LIBS"/g' -i libindicator-$version/configure
+  sed 's/LIBS="-lmw  $LIBS"/LIBS=" -lmw  $LIBS"/g' -i libindicator-$version/configure
+  sed 's/LIBM="-lm"/LIBM=" -lm"/g' -i libindicator-$version/m4/libtool.m4
+
+  cd libindicator-$version
+
+  ./configure --prefix=/usr                \
+              --sysconfdir=/etc            \
+              --localstatedir=/var         \
+              --libexecdir=/usr/lib/$name  \
+              --disable-static             \
+			  --disable-tests              \
+              --with-gtk=3
+make -j1
+make -j1 DESTDIR=$PKG install
+}


### PR DESCRIPTION
Prérequis pour mate-system-monitor 1.18.